### PR TITLE
Fix the hidden state norm stabilization code for PyTorch v0.3.1, and

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -295,7 +295,7 @@ class Trainer(object):
                                                     hidden,
                                                     dags)
             hidden = utils.detach(hidden)
-            raw_total_loss += loss
+            raw_total_loss += loss.data
 
             loss += _apply_penalties(extra_out, self.args)
 
@@ -337,7 +337,8 @@ class Trainer(object):
 
         inputs, targets = self.get_batch(self.valid_data,
                                          valid_idx,
-                                         self.max_length)
+                                         self.max_length,
+                                         volatile=True)
         valid_loss, hidden, _ = self.get_loss(inputs, targets, hidden, dag)
         valid_loss = utils.to_item(valid_loss.data)
 

--- a/utils.py
+++ b/utils.py
@@ -170,7 +170,6 @@ def to_item(x):
     if isinstance(x, (float, int)):
         return x
 
-    assert torch.is_tensor(x)
     if float(torch.__version__[0:3]) < 0.4:
         assert (x.dim() == 1) and (len(x) == 1)
         return x[0]


### PR DESCRIPTION
reduce the noise created by logging clipped hidden states.

Sorry, this fixes a few bugs that were still present after my last commit (adding PyTorch v0.3.1 compatibility). I've tested now for v0.4 and v0.3.1 and training seems to be working for both.