### PR TITLE
set default of `valid_idx` to 0 in `get_reward`

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -325,15 +325,12 @@ class Trainer(object):
             self.shared_step += 1
             train_idx += self.max_length
 
-    def get_reward(self, dag, entropies, hidden, valid_idx=None):
+    def get_reward(self, dag, entropies, hidden, valid_idx=0):
         """Computes the perplexity of a single sampled model on a minibatch of
         validation data.
         """
         if not isinstance(entropies, np.ndarray):
             entropies = entropies.data.cpu().numpy()
-
-        if valid_idx:
-            valid_idx = 0
 
         inputs, targets = self.get_batch(self.valid_data,
                                          valid_idx,


### PR DESCRIPTION
The value of `valid_idx` would always be overwritten by the if block.
I think the author intended to write:

```python
if not valid_idx:
    valid_idx = 0
```

But forgot the `not` in the condition. In fact instead of adding the `not` we can get rid of the if block and set the `valid_idx` parameter to a default value of 0.

Before this update, omitting to give the optional parameter `valid_idx` would produce an exception.